### PR TITLE
Add timeout to deploy and file defines

### DIFF
--- a/manifests/deploy.pp
+++ b/manifests/deploy.pp
@@ -7,6 +7,7 @@ define staging::deploy (
   $certificate  = undef,
   $password     = undef,
   $environment  = undef,
+  $timeout      = undef,
   # staging extract settings:
   $user         = undef,
   $group        = undef,
@@ -23,6 +24,7 @@ define staging::deploy (
     password           => $password,
     environment        => $environment,
     caller_module_name => $caller_module_name,
+    timeout            => $timeout,
   }
 
   staging::extract { $name:

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -14,6 +14,7 @@
 #   * password: https or ftp user password or https certificate password.
 #   * environment: environment variable for settings such as http_proxy,
 #   https_proxy, of ftp_proxy.
+#   * timeout: the the time to wait for the file transfer to complete
 #
 # Usage:
 #
@@ -31,6 +32,7 @@ define staging::file (
   $certificate = undef,
   $password    = undef,
   $environment = undef,
+  $timeout     = undef,
   # allowing pass through of real caller.
   $caller_module_name = $caller_module_name
 ) {
@@ -56,6 +58,7 @@ define staging::file (
     environment => $environment,
     cwd         => $staging_dir,
     creates     => $target_file,
+    timeout     => $timeout,
   }
 
   case $source {


### PR DESCRIPTION
If a download takes longer than 5 minutes, the exec will time out and
will be terminated. Since this module can be expected to download very
large files, this timeout needs to be controllable.
