### PR TITLE
Display output on fail for execs in deploy::file

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -60,6 +60,7 @@ define staging::file (
     cwd         => $staging_dir,
     creates     => $target_file,
     timeout     => $timeout,
+    logoutput   => on_failure,
   }
 
   case $source {

--- a/spec/defines/staging_file_spec.rb
+++ b/spec/defines/staging_file_spec.rb
@@ -40,6 +40,7 @@ describe 'staging::file', :type => :define do
         :environment => nil,
         :cwd         => '/opt/staging/spec',
         :creates     => '/opt/staging/spec/sample.tar.gz',
+        :logoutput   => 'on_failure',
       })
     }
   end
@@ -72,6 +73,7 @@ describe 'staging::file', :type => :define do
        :environment => nil,
        :cwd         => '/opt/staging/spec',
        :creates     => '/opt/staging/spec/sample.tar.gz',
+       :logoutput   => 'on_failure',
      }) }
   end
 
@@ -90,6 +92,7 @@ describe 'staging::file', :type => :define do
         :environment => nil,
         :cwd         => '/opt/staging/spec',
         :creates     => '/opt/staging/spec/sample.tar.gz',
+        :logoutput   => 'on_failure',
       })
     }
   end
@@ -106,6 +109,7 @@ describe 'staging::file', :type => :define do
         :environment => nil,
         :cwd         => '/opt/staging/spec',
         :creates     => '/opt/staging/spec/sample.tar.gz',
+        :logoutput   => 'on_failure',
       })
     }
   end
@@ -125,6 +129,7 @@ describe 'staging::file', :type => :define do
         :environment => nil,
         :cwd         => '/opt/staging/spec',
         :creates     => '/opt/staging/spec/sample.tar.gz',
+        :logoutput   => 'on_failure',
       })
     }
   end


### PR DESCRIPTION
If a command fails while downloading a file for staging, only the return
code will be provided, limiting the amount of debugging possible. This
enables logging upon failure to help diagnose issues.
