### PR TITLE
Make curl error on 404

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -63,9 +63,9 @@ define staging::file (
     /^http:\/\//: {
 
       if $username {
-        $command = "curl -L -o ${name} -u ${username}:${password} ${source}"
+        $command = "curl -f -L -o ${name} -u ${username}:${password} ${source}"
       } else {
-        $command = "curl -L -o ${name} ${source}"
+        $command = "curl -f -L -o ${name} ${source}"
       }
 
       exec { $target_file:
@@ -75,11 +75,11 @@ define staging::file (
 
     /^https:\/\//: {
       if $username {
-        $command = "curl -L -o ${name} -u ${username}:${password} ${source}"
+        $command = "curl -f -L -o ${name} -u ${username}:${password} ${source}"
       } elsif $certificate {
-        $command = "curl -L -o ${name} -E ${certificate}:${password} ${source}"
+        $command = "curl -f -L -o ${name} -E ${certificate}:${password} ${source}"
       } else {
-        $command = "curl -L -o ${name} ${source}"
+        $command = "curl -f -L -o ${name} ${source}"
       }
 
       exec { $target_file:

--- a/spec/defines/staging_file_spec.rb
+++ b/spec/defines/staging_file_spec.rb
@@ -35,7 +35,7 @@ describe 'staging::file', :type => :define do
     it {
       should contain_file('/opt/staging')
       should contain_exec('/opt/staging/spec/sample.tar.gz').with( {
-        :command => 'curl -L -o sample.tar.gz http://webserver/sample.tar.gz',
+        :command => 'curl -f -L -o sample.tar.gz http://webserver/sample.tar.gz',
         :path        => '/usr/local/bin:/usr/bin:/bin',
         :environment => nil,
         :cwd         => '/opt/staging/spec',
@@ -53,7 +53,7 @@ describe 'staging::file', :type => :define do
 
     it { should contain_file('/opt/staging')
       should contain_exec('/usr/local/sample.tar.gz').with( {
-        :command => 'curl -L -o sample.tar.gz http://webserver/sample.tar.gz',
+        :command => 'curl -f -L -o sample.tar.gz http://webserver/sample.tar.gz',
         :path        => '/usr/local/bin:/usr/bin:/bin',
         :environment => nil,
         :cwd         => '/usr/local',
@@ -68,7 +68,7 @@ describe 'staging::file', :type => :define do
 
      it { should contain_file('/opt/staging') }
      it { should contain_exec('/opt/staging/spec/sample.tar.gz').with( {
-       :command => 'curl -L -o sample.tar.gz https://webserver/sample.tar.gz',
+       :command => 'curl -f -L -o sample.tar.gz https://webserver/sample.tar.gz',
        :path        => '/usr/local/bin:/usr/bin:/bin',
        :environment => nil,
        :cwd         => '/opt/staging/spec',
@@ -87,7 +87,7 @@ describe 'staging::file', :type => :define do
     it {
       should contain_file('/opt/staging')
       should contain_exec('/opt/staging/spec/sample.tar.gz').with( {
-        :command => 'curl -L -o sample.tar.gz -u puppet:puppet https://webserver/sample.tar.gz',
+        :command => 'curl -f -L -o sample.tar.gz -u puppet:puppet https://webserver/sample.tar.gz',
         :path        => '/usr/local/bin:/usr/bin:/bin',
         :environment => nil,
         :cwd         => '/opt/staging/spec',


### PR DESCRIPTION
Normally a webserver will return an html document when a 404 is
encountered. By default curl will download this html and return 0. This
pull request causes curl to return 22 instead, thus making the
staging::file resource fail on 404.
