### PR TITLE
Set staging::extract's timeout in staging::deploy.

### DIFF
--- a/manifests/deploy.pp
+++ b/manifests/deploy.pp
@@ -2,18 +2,24 @@
 define staging::deploy (
   $source,               #: the source file location, supports local files, puppet://, http://, https://, ftp://
   $target,               #: the target extraction directory
-  $staging_path = undef, #: the staging location for compressed file. defaults to ${staging::path}/${caller_module_name}
-  $username     = undef, #: https or ftp username
-  $certificate  = undef, #: https certifcate file
-  $password     = undef, #: https or ftp user password or https certificate password
-  $environment  = undef, #: environment variable for settings such as http_proxy
-  $timeout      = undef, #: the time to wait for the file transfer to complete
-  $user         = undef, #: extract file as this user
-  $group        = undef, #: extract group as this group
-  $creates      = undef, #: the file/folder created after extraction. if unspecified defaults to ${target}/${name}
-  $unless       = undef, #: alternative way to conditionally extract file
-  $onlyif       = undef  #: alternative way to conditionally extract file
+  $staging_path    = undef, #: the staging location for compressed file. defaults to ${staging::path}/${caller_module_name}
+  $username        = undef, #: https or ftp username
+  $certificate     = undef, #: https certifcate file
+  $password        = undef, #: https or ftp user password or https certificate password
+  $environment     = undef, #: environment variable for settings such as http_proxy
+  $timeout         = undef, #: the time to wait for the file transfer to complete
+  $extract_timeout = undef, #: the time to wait for the extraction to complete
+  $user            = undef, #: extract file as this user
+  $group           = undef, #: extract group as this group
+  $creates         = undef, #: the file/folder created after extraction. if unspecified defaults to ${target}/${name}
+  $unless          = undef, #: alternative way to conditionally extract file
+  $onlyif          = undef  #: alternative way to conditionally extract file
 ) {
+
+  $use_extract_timeout = $extract_timeout ? {
+    undef   => $timeout,         # default to the same as $timeout if unset
+    default => $extract_timeout, # otherwise, use it as-is if set
+  }
 
   staging::file { $name:
     source      => $source,
@@ -34,6 +40,7 @@ define staging::deploy (
     environment => $environment,
     subdir      => $caller_module_name,
     creates     => $creates,
+    timeout     => $use_extract_timeout,
     unless      => $unless,
     onlyif      => $onlyif,
     require     => Staging::File[$name],

--- a/manifests/extract.pp
+++ b/manifests/extract.pp
@@ -8,6 +8,7 @@ define staging::extract (
   $user        = undef, #: extract file as this user.
   $group       = undef, #:  extract file as this group.
   $environment = undef, #: environment variables.
+  $timeout     = undef, #: exec timeout for extraction
   $subdir      = $caller_module_name #: subdir per module in staging directory.
 ) {
 
@@ -40,6 +41,7 @@ define staging::extract (
       group       => $group,
       environment => $environment,
       creates     => $creates_path,
+      timeout     => $timeout,
       unless      => $unless,
       onlyif      => $onlyif,
       logoutput   => on_failure,
@@ -52,6 +54,7 @@ define staging::extract (
       group       => $group,
       environment => $environment,
       creates     => $creates_path,
+      timeout     => $timeout,
       unless      => $unless,
       onlyif      => $onlyif,
       logoutput   => on_failure,


### PR DESCRIPTION
I've opted to have extract's timeout default to the same value as file's, which changes the theoretical maximum execution time from $timeout + 5 minutes (exec's default timeout) to 2 \* $timeout. To give users more control, there's a new, optional $extract_timeout parameter that affects only the extract stage.

I've also added the corresponding timeout parameter to staging::extract.
