### PR TITLE
[staging_parse] Raise error if given invalid source

### DIFF
--- a/lib/puppet/parser/functions/staging_parse.rb
+++ b/lib/puppet/parser/functions/staging_parse.rb
@@ -11,6 +11,10 @@ Parse filepath to retrieve information about the file.
 
     source    = arguments[0]
     path      = URI.parse(source).path
+
+    raise Puppet::ParseError, "staging_parse(): #{source.inspect} has no URI " +
+      "'path' component" if path.nil?
+
     info      = arguments[1] ? arguments[1] : 'filename'
     extension = arguments[2] ? arguments[2] : File.extname(path)
 

--- a/spec/unit/puppet/parser/functions/staging_parse_spec.rb
+++ b/spec/unit/puppet/parser/functions/staging_parse_spec.rb
@@ -26,6 +26,10 @@ describe "the staging parser function" do
     lambda { @scope.function_staging_parse(['/etc', 'sheep', '.zip']) }.should( raise_error(Puppet::ParseError))
   end
 
+  it "should raise a ParseError if 'source' doesn't have a URI path component" do
+    lambda { @scope.function_staging_parse(['uri:without-path']) }.should( raise_error(Puppet::ParseError, /has no URI 'path' component/))
+  end
+
   it "should return the filename by default" do
     result = @scope.function_staging_parse(["/etc/puppet/sample.tar.gz"])
     result.should(eq('sample.tar.gz'))


### PR DESCRIPTION
A string like 'foo:bar' is a valid URI but contains no path.
URI.parse('foo:bar') returns nil, and calling File.extname(nil) raises
"can't convert nil into String".

This commit ensures that the given URI has a valid path and fails early
if the input is malformed.
