### PR TITLE
Handle URLs with parameters more sensibly.

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -24,6 +24,8 @@ define staging::file (
 
   include staging
 
+  $quoted_source = shellquote($source)
+
   if $target {
     $target_file = $target
     $staging_dir = staging_parse($target, 'parent')
@@ -49,16 +51,16 @@ define staging::file (
 
   case $::staging_http_get {
     'curl', default: {
-      $http_get        = "curl ${curl_option} -f -L -o ${name} ${source}"
-      $http_get_passwd = "curl ${curl_option} -f -L -o ${name} -u ${username}:${password} ${source}"
-      $http_get_cert   = "curl ${curl_option} -f -L -o ${name} -E ${certificate}:${password} ${source}"
-      $ftp_get         = "curl ${curl_option} -o ${name} ${source}"
-      $ftp_get_passwd  = "curl ${curl_option} -o ${name} -u ${username}:${password} ${source}"
+      $http_get        = "curl ${curl_option} -f -L -o ${name} ${quoted_source}"
+      $http_get_passwd = "curl ${curl_option} -f -L -o ${name} -u ${username}:${password} ${quoted_source}"
+      $http_get_cert   = "curl ${curl_option} -f -L -o ${name} -E ${certificate}:${password} ${quoted_source}"
+      $ftp_get         = "curl ${curl_option} -o ${name} ${quoted_source}"
+      $ftp_get_passwd  = "curl ${curl_option} -o ${name} -u ${username}:${password} ${quoted_source}"
     }
     'wget': {
-      $http_get        = "wget ${wget_option} -O ${name} ${source}"
-      $http_get_passwd = "wget ${wget_option} -O ${name} --user=${username} --password=${password} ${source}"
-      $http_get_cert   = "wget ${wget_option} -O ${name} --user=${username} --certificate=${certificate} ${source}"
+      $http_get        = "wget ${wget_option} -O ${name} ${quoted_source}"
+      $http_get_passwd = "wget ${wget_option} -O ${name} --user=${username} --password=${password} ${quoted_source}"
+      $http_get_cert   = "wget ${wget_option} -O ${name} --user=${username} --certificate=${certificate} ${quoted_source}"
       $ftp_get         = $http_get
       $ftp_get_passwd  = $http_get_passwd
     }


### PR DESCRIPTION
Shellquote is the closest thing to array-of-arguments exec calls puppet supports. As far as I've ever been able to test, it correctly handles quoting for the shells Puppet uses for `exec{}` resources. Using it to construct `curl`/`wget` commands means that they correctly download, for example, Jetty:

```
http://eclipse.org/downloads/download.php?file=/jetty/stable-8/dist/jetty-distribution-8.1.14.v20131031.tar.gz&r=1
```

Without shellquote, the `exec` resources see the embedded `&` near the end and generate two shell commands (the second of which is `r=1`). With shellquote, the URL is kept as a single argument.

I had a look at retrofitting the command lines in the `extract.pp` manifest, but it's not so worth it there, I think.
