### PR TITLE
Add /usr/sfw/bin to the solaris path

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,13 @@ class staging::params {
       $mode      = '0755'
       $exec_path = '/usr/local/bin:/usr/bin:/bin'
     }
+    'Solaris': {
+      $path      = '/opt/staging'
+      $owner     = '0'
+      $group     = '0'
+      $mode      = '0755'
+      $exec_path = '/usr/local/bin:/usr/bin:/bin:/usr/sfw/bin'
+    }
     'windows': {
       $path      = $::staging_windir
       $owner     = undef


### PR DESCRIPTION
This is because on Solaris, wget is available in the non-standard path /usr/sfw/bin as a last resort. This is a "step in the right direction" iteration kind of commit.
