### PR TITLE
Homogenize path-separator in staging_parse

### DIFF
--- a/lib/puppet/parser/functions/staging_parse.rb
+++ b/lib/puppet/parser/functions/staging_parse.rb
@@ -10,7 +10,7 @@ Parse filepath to retrieve information about the file.
       "given (#{arguments.size} for 1, 2, 3)") if arguments.size < 1 || arguments.size > 3
 
     source    = arguments[0]
-    path      = URI.parse(source).path
+    path      = URI.parse(source.gsub('\\', '/')).path
 
     raise Puppet::ParseError, "staging_parse(): #{source.inspect} has no URI " +
       "'path' component" if path.nil?


### PR DESCRIPTION
The staging_parse() function manipulates input using Ruby libraries and path logic. However, the Ruby URI library expects that (even on Windows) paths will use "/" as a separator. Rather than special-case everything, resolve this inconsistency regarding Windows paths by enforcing that backslashes will simply be converted to forward-slashes before trying to operate on them with staging_parse(). Otherwise, using a source or target in the form of a Windows path with backslashes will cause the staging_parse() function to abort.
