### PR TITLE
On Windows, use well-known SIDs to set ownership

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,9 +17,9 @@ class staging::params {
     }
     'windows': {
       $path      = $::staging_windir
-      $owner     = undef
-      $group     = undef
-      $mode      = '0755'
+      $owner     = 'S-1-5-32-544' # Adminstrators
+      $group     = 'S-1-5-18'     # SYSTEM
+      $mode      = '0660'
       $exec_path = $::path
     }
   }


### PR DESCRIPTION
This is per the recommendation of Josh Cooper. We want to ensure that
non-privileged users don't have access to the directory. This should be
the rough equivalent of setting owner=root group=root on Unix.
