### PR TITLE
add staging::verify

### DIFF
--- a/manifests/deploy.pp
+++ b/manifests/deploy.pp
@@ -2,6 +2,8 @@
 define staging::deploy (
   $source,               #: the source file location, supports local files, puppet://, http://, https://, ftp://
   $target,               #: the target extraction directory
+  $checksum = undef,
+  $checksum_algorithm = undef,
   $staging_path = undef, #: the staging location for compressed file. defaults to ${staging::path}/${caller_module_name}
   $username     = undef, #: https or ftp username
   $certificate  = undef, #: https certifcate file
@@ -24,6 +26,17 @@ define staging::deploy (
     environment => $environment,
     subdir      => $caller_module_name,
     timeout     => $timeout,
+  }
+
+  if $checksum != undef {
+    staging::verify { $name:
+      checksum    => $checksum,
+      algorithm   => $checksum_algorithm,
+      subdir      => $caller_module_name,
+      refreshonly => true,
+      subscribe   => Staging::File[$name],
+      before      => Staging::Extract[$name],
+    }
   }
 
   staging::extract { $name:

--- a/manifests/verify.pp
+++ b/manifests/verify.pp
@@ -1,0 +1,23 @@
+# Define resource to verify checksums of files in staging directories
+define staging::verify (
+  $checksum,
+  $algorithm = 'sha1',
+  $subdir    = $caller_module_name,
+  $refreshonly = undef,
+) {
+  include staging
+
+  $staging_dir = "${staging::path}/${subdir}"
+  $command = "${algorithm}sum --check --quiet --status"
+
+  Exec {
+    path        => $staging::exec_path,
+    cwd         => $staging_dir,
+    logoutput   => on_failure,
+    refreshonly => $refreshonly,
+  }
+
+  exec { "verify ${name} with ${algorithm}":
+    command => "echo '${checksum}  ${name}' | ${command}",
+  }
+}

--- a/tests/deploy.pp
+++ b/tests/deploy.pp
@@ -1,4 +1,5 @@
 staging::deploy { 'sample.tar.gz':
-  source => 'puppet:///modules/staging/sample.tar.gz',
-  target => '/usr/local',
+  source   => 'puppet:///modules/staging/sample.tar.gz',
+  target   => '/usr/local',
+  checksum => 'e4ad1353b2becccbc9ff49d10b8980f17eadce57',
 }

--- a/tests/verify.pp
+++ b/tests/verify.pp
@@ -1,0 +1,3 @@
+staging::verify { 'sample.tar.gz':
+  checksum => 'e4ad1353b2becccbc9ff49d10b8980f17eadce57',
+}


### PR DESCRIPTION
Allows the validation of staging archives. It uses the *sum family of programms on the agent machine.
Users can choose to validate on every run or after download.
