### PR TITLE
Pass full path as name in staging::deploy

### DIFF
--- a/manifests/deploy.pp
+++ b/manifests/deploy.pp
@@ -1,7 +1,7 @@
 # The define resource extracts compressed file to a staging location.
 define staging::deploy (
-  $source,               #: the source file location, supports local files, puppet://, http://, https://, ftp://
   $target,               #: the target extraction directory
+  $source       = undef, #: the source file location, supports local files, puppet://, http://, https://, ftp://
   $staging_path = undef, #: the staging location for compressed file. defaults to ${staging::path}/${caller_module_name}
   $username     = undef, #: https or ftp username
   $certificate  = undef, #: https certifcate file
@@ -17,8 +17,21 @@ define staging::deploy (
   $onlyif       = undef  #: alternative way to conditionally extract file
 ) {
 
-  staging::file { $name:
-    source      => $source,
+  # grab file name if path was passed in
+  if $name =~ /.*\/(.*)/ {
+    $file_name = $1
+  } else {
+    $file_name = $name
+  }
+
+  if $source {
+    $source_path = $source
+  } else {
+    $source_path = $name
+  }
+
+  staging::file { $file_name:
+    source      => $source_path,
     target      => $staging_path,
     username    => $username,
     certificate => $certificate,
@@ -28,7 +41,7 @@ define staging::deploy (
     timeout     => $timeout,
   }
 
-  staging::extract { $name:
+  staging::extract { $file_name:
     target      => $target,
     source      => $staging_path,
     user        => $user,
@@ -40,7 +53,7 @@ define staging::deploy (
     creates     => $creates,
     unless      => $unless,
     onlyif      => $onlyif,
-    require     => Staging::File[$name],
+    require     => Staging::File[$file_name],
   }
 
 }

--- a/spec/defines/staging_deploy_spec.rb
+++ b/spec/defines/staging_deploy_spec.rb
@@ -24,6 +24,34 @@ describe 'staging::deploy', type: :define do
     }
   end
 
+  describe 'when deploying tar.gz with full path in title and no source' do
+    let(:title) { 'puppet:///modules/staging/sample.tar.gz' }
+    let(:params) {{
+      target: '/usr/local'
+    }}
+
+    it { should contain_file('/opt/staging') }
+    it { should contain_file('/opt/staging//sample.tar.gz') }
+    it {
+      should contain_exec('extract sample.tar.gz').with(command: 'tar xzf /opt/staging//sample.tar.gz',
+                                                        path: '/usr/local/bin:/usr/bin:/bin',
+                                                        cwd: '/usr/local',
+                                                        creates: '/usr/local/sample')
+    }
+  end
+
+  describe 'fail when deploying tar.gz with filename in title and no source' do
+    let(:title) { 'sample.tar.gz' }
+    let(:params) {{
+      target: '/usr/local'
+    }}
+
+    it do
+      expect { should contain_exec('extract sample.tar.gz')
+      }.to raise_error(Puppet::Error, %r{do not recognize source})
+    end
+  end
+
   describe 'when deploying tar.gz with strip' do
     let(:title) { 'sample.tar.gz' }
     let(:params) {{


### PR DESCRIPTION
I was using your module, and I noticed that if you pass in the full path to staging::deploy, it tries to use the full url as the name, which causes the file to be put in nested directories under the default stage.

When staging::extract is looking for the file, it looks where you would expect the file to be, but not where deploy puts it.

Thanks for considering my PR!