### PR TITLE
Add support for OpenBSD, very similar to FreeBSD.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,5 +29,12 @@ class staging::params {
       $mode      = '0755'
       $exec_path = '/usr/local/bin:/usr/bin:/bin'
     }
+    'OpenBSD': {
+      $path      = '/var/staging'
+      $owner     = '0'
+      $group     = '0'
+      $mode      = '0755'
+      $exec_path = '/usr/local/bin:/usr/bin:/bin'
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -82,6 +82,15 @@
         "6.1",
         "7.1"
       ]
+    },
+    {
+      "operatingsystem": "OpenBSD",
+      "operatingsystemrelease": [
+        "5.7",
+        "5.8",
+        "5.9",
+        "6.0"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
On OpenBSD /var/tmp is linked to /tmp, and so it is cleaned
on each reboot of the box, therefore not optimal.