### PR TITLE
Fixed error in staging_windir.rb fact.

### DIFF
--- a/lib/facter/staging_windir.rb
+++ b/lib/facter/staging_windir.rb
@@ -1,5 +1,5 @@
 Facter.add(:staging_windir) do
-  confine osfamily: :windows
+  confine :osfamily => :windows
   setcode do
     program_data = `echo %SYSTEMDRIVE%\\ProgramData`.chomp
     if File.directory? program_data


### PR DESCRIPTION
Fix:

Info: Loading facts
Error loading fact /var/lib/puppet/lib/facter/staging_windir.rb: /var/lib/puppet/lib/facter/staging_windir.rb:2: syntax error, unexpected ':', expecting kEND
  confine osfamily: :windows
                   ^


