### PR TITLE
Set owner, group, mode explicitly so things work even with umask 027.

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -40,7 +40,10 @@ define staging::file (
 
     if ! defined(File[$staging_dir]) {
       file { $staging_dir:
-        ensure=>directory,
+        ensure => 'directory',
+        owner  => $staging::owner,
+        group  => $staging::group,
+        mode   => $staging::mode,
       }
     }
   }


### PR DESCRIPTION
Our machines py policy run with a default umask of 027; when files and directories are created by Puppet without specifying a mode explicitly, this usually leads to files not being accessible.

This change addresses the one place that the owner, group, and mode were not set.
